### PR TITLE
Icp function tolerance parameter should be double

### DIFF
--- a/icp.cpp
+++ b/icp.cpp
@@ -69,7 +69,7 @@ typedef struct{
 }  ICP_OUT;
 */
 
-ICP_OUT icp(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B, int max_iterations, int tolerance){
+ICP_OUT icp(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B, int max_iterations, double tolerance){
     int row = A.rows();
     Eigen::MatrixXd src = Eigen::MatrixXd::Ones(3+1,row);
     Eigen::MatrixXd src3d = Eigen::MatrixXd::Ones(3,row);

--- a/icp.h
+++ b/icp.h
@@ -24,7 +24,7 @@ typedef struct{
 
 Eigen::Matrix4d best_fit_transform(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B);
 
-ICP_OUT icp(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B, int max_iterations=20, int tolerance = 0.001);
+ICP_OUT icp(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B, int max_iterations=20, double tolerance = 0.001);
 
 // throughout method
 NEIGHBOR nearest_neighbot(const Eigen::MatrixXd &src, const Eigen::MatrixXd &dst);


### PR DESCRIPTION
icp function: changed tolerance parameter from int to double, otherwise it is always rounded to zero and never taken into account.